### PR TITLE
Set startingDeadlineSeconds

### DIFF
--- a/kubernetes/tmpl/cron_job_template.yml.erb
+++ b/kubernetes/tmpl/cron_job_template.yml.erb
@@ -14,6 +14,7 @@ spec:
   suspend: false
   successfulJobsHistoryLimit: 10
   failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
   jobTemplate:
     metadata:
       name: ev-job

--- a/spec/data/cron_job_manifest.yml
+++ b/spec/data/cron_job_manifest.yml
@@ -14,6 +14,7 @@ spec:
   suspend: false
   successfulJobsHistoryLimit: 10
   failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
   jobTemplate:
     metadata:
       name: ev-job


### PR DESCRIPTION
## WHY

Below error was occurred:

```
Cannot determine if job needs to be started: Too many missed start time (> 100). Set or decrease .spec.startingDeadlineSeconds or check clock skew.
```

It should be specified `startingDeadlineSeconds` following this error message.

## WHAT

Add `startingDeadlineSeconds` to the cronJob template.