### PR TITLE
Do not evict job pod in running

### DIFF
--- a/kubernetes/tmpl/cron_job_template.yml.erb
+++ b/kubernetes/tmpl/cron_job_template.yml.erb
@@ -31,4 +31,6 @@ spec:
             name: ev-job
             app: ev-job
             role: job
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         spec: <%= spec %>

--- a/spec/data/cron_job_manifest.yml
+++ b/spec/data/cron_job_manifest.yml
@@ -31,6 +31,8 @@ spec:
             name: ev-job
             app: ev-job
             role: job
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         spec:
           imagePullSecrets:
           - name: wantedlybotkey


### PR DESCRIPTION
## WHY

[cluster-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) can evict a running job pod.

## WHAT

added `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` annotation to prevent to stop pod.